### PR TITLE
Add support for Smarty 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "smarty/smarty": "~3.1",
+        "smarty/smarty": "^3.1|^4.0",
         "slim/slim": "^4.0"
     },
     "require-dev": {


### PR DESCRIPTION
This library does not seem to use any of the [removed](https://github.com/smarty-php/smarty/blob/master/CHANGELOG.md#removed) functionalities.
I tried running my Slim app with smarty-view 1.1.2 and smarty 4.0.4, and everything seems to work correctly.