### PR TITLE
Add support for Smarty 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "smarty/smarty": "~3.1",
+        "smarty/smarty": "^3.1|^4.0",
         "slim/slim": "^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
Same as https://github.com/mathmarques/Smarty-View/pull/10 but for 1.x.