### PR TITLE
PHP 8 interface compatibility

### DIFF
--- a/src/Smarty.php
+++ b/src/Smarty.php
@@ -154,6 +154,7 @@ class Smarty implements \ArrayAccess
      *
      * @return mixed The key's value, or the default value
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($key)
     {
         return $this->defaultVariables[$key];
@@ -165,6 +166,7 @@ class Smarty implements \ArrayAccess
      * @param string $key The data key
      * @param mixed $value The data value
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($key, $value)
     {
         $this->defaultVariables[$key] = $value;
@@ -175,6 +177,7 @@ class Smarty implements \ArrayAccess
      *
      * @param string $key The data key
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($key)
     {
         unset($this->defaultVariables[$key]);


### PR DESCRIPTION
Add ReturnTypeWillChange attribute to silence the deprecation notice emitted by the fact that, for the methods annotated, the implementation of ArrayAccess methods do not declare a compatible return type.